### PR TITLE
janus.js - Prevent screenshare `getUserMedia` audio only track

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2370,7 +2370,7 @@ function Janus(gatewayCallbacks) {
 						navigator.mediaDevices.getDisplayMedia(constraints)
 							.then(function(stream) {
 								pluginHandle.consentDialog(false);
-								if(isAudioSendEnabled(media) && !media.keepAudio) {
+								if(isAudioSendEnabled(media) && !media.keepAudio && !media.preventGetUserMedia) {
 									navigator.mediaDevices.getUserMedia({ audio: true, video: false })
 									.then(function (audioStream) {
 										stream.addTrack(audioStream.getAudioTracks()[0]);


### PR DESCRIPTION
Adds media property to prevent getUserMedia call to better control the audio track of the screenshare stream.

Chrome `getDisplayMedia` has a "share audio" checkbox that when checked can share system or tab specific audio.
![Screenshot from 2022-11-04 15-55-17](https://user-images.githubusercontent.com/24800059/200080859-8f546651-1154-4c63-afa1-b6ba180060ca.png)

In order for other participants to hear audio from this feature, `isAudioSendEnabled(media)` must be `true`.

**BUT** if the user *does not* check "share audio" and `isAudioSendEnabled(media)` is `true`, janus.js will then call `getUserMedia({ audio: true, video: false })` and send the user's audio. In my case, the user is already publishing their audio & video so this duplicates the transmitter's audio for the participants (audio is being transmitted through their audio/video handle AND their screenshare handle).

The change added here prevents janus.js from calling `getUserMedia({ audio: true, video: false })`.