### PR TITLE
janus.js - `callbacks.error` send original error object

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2551,7 +2551,7 @@ function Janus(gatewayCallbacks) {
 								streamsDone(handleId, jsep, media, callbacks, stream);
 							}).catch(function(error) {
 								pluginHandle.consentDialog(false);
-								callbacks.error({code: error.code, name: error.name, message: error.message});
+								callbacks.error({code: error.code, name: error.name, message: error.message, error});
 							});
 					}
 				})

--- a/html/janus.js
+++ b/html/janus.js
@@ -2370,7 +2370,7 @@ function Janus(gatewayCallbacks) {
 						navigator.mediaDevices.getDisplayMedia(constraints)
 							.then(function(stream) {
 								pluginHandle.consentDialog(false);
-								if(isAudioSendEnabled(media) && !media.keepAudio) {
+								if(isAudioSendEnabled(media) && !media.keepAudio && !media.preventGetUserMedia) {
 									navigator.mediaDevices.getUserMedia({ audio: true, video: false })
 									.then(function (audioStream) {
 										stream.addTrack(audioStream.getAudioTracks()[0]);


### PR DESCRIPTION
Includes the original `error` object when `navigator.mediaDevices.getUserMedia` raises an exception.

## Use case

In the case of an `OverconstrainedError`, the `constraint` property is not sent to the `callbacks.error` function. Commit https://github.com/kmeyerhofer/janus-gateway/commit/58a1c969017085398abcddec8f610ade5f7e2dd4 includes the original object to the callback for application processing and logging.

This PR builds upon #1. An eventual merge to the original `janus-gateway` repository will require these PRs to be separated.